### PR TITLE
Implement allow_unreadable in lume.serialize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,11 +326,14 @@ local f = lume.lambda "x,y -> 2*x+y"
 f(10, 5) -- Returns 25
 ```
 
-### lume.serialize(x)
-Serializes the argument `x` into a string which can be loaded again using
-`lume.deserialize()`. Only booleans, numbers, tables and strings can be
-serialized. Circular references will result in an error; all nested tables are
-serialized as unique tables.
+### lume.serialize(x, allow_unreadable)
+Serializes the argument `x` into a string which can be loaded again
+using `lume.deserialize()`. All nested tables are serialized as unique
+tables. Only booleans, numbers, tables and strings can be deserialized. By
+default serializing things which cannot be deserialized will result in an
+error, but if the second `allow_unreadable` argument is true then they will
+be included in the output. Likewise circular tables will result in an error
+normally, but can be included in a non-deserializable way with this arg set.
 ```lua
 lume.serialize({a = "test", b = {1, 2, 3}, false})
 -- Returns "{[1]=false,["a"]="test",["b"]={[1]=1,[2]=2,[3]=3,},}"

--- a/lume.lua
+++ b/lume.lua
@@ -536,6 +536,8 @@ end
 
 local serialize
 
+local serialize_unreadable = false
+
 local serialize_map = {
   [ "boolean" ] = tostring,
   [ "nil"     ] = tostring,
@@ -548,7 +550,13 @@ local serialize_map = {
   end,
   [ "table"   ] = function(t, stk)
     stk = stk or {}
-    if stk[t] then error("circular reference") end
+    if stk[t] then
+       if serialize_unreadable then
+          return "#<circular " .. tostring(t) .. ">"
+       else
+          error("circular reference")
+       end
+    end
     local rtn = {}
     stk[t] = true
     for k, v in pairs(t) do
@@ -560,15 +568,24 @@ local serialize_map = {
 }
 
 setmetatable(serialize_map, {
-  __index = function(_, k) error("unsupported serialize type: " .. k) end
+                __index = function(_, k)
+                   return function(v)
+                      if serialize_unreadable then
+                         return "#<" .. tostring(v) .. ">"
+                      else
+                         error("unsupported serialize type: " .. k)
+                      end
+                   end
+                end
 })
 
 serialize = function(x, stk)
   return serialize_map[type(x)](x, stk)
 end
 
-function lume.serialize(x)
-  return serialize(x)
+function lume.serialize(x, allow_unreadable)
+   serialize_unreadable = allow_unreadable
+   return serialize(x)
 end
 
 


### PR DESCRIPTION
For my game I need to be able to display serialized Lua objects even in cases where they cannot be deserialized again, so I added this argument to `lume.serialize` (false by default) which will insert `#<function: 0x2481094>` etc when it encounters objects that would otherwise result in an error.

Feel free to reject this if you don't think it belongs in Lume; I thought I would just throw it out to see if you were interested.