### PR TITLE
Add rockspecs

### DIFF
--- a/lume-scm-1.rockspec
+++ b/lume-scm-1.rockspec
@@ -1,0 +1,20 @@
+package = "lume"
+version = "scm-1"
+source = {
+   url = "git://github.com/rxi/lume"
+}
+description = {
+   summary = "A collection of functions for Lua, geared towards game development.",
+   detailed = "A collection of functions for Lua, geared towards game development.",
+   homepage = "http://github.com/rxi/lume",
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1, < 5.4"
+}
+build = {
+   type = "builtin",
+   modules = {
+      lume = "lume.lua"
+   }
+}

--- a/rockspecs/lume-2.2.3-1.rockspec
+++ b/rockspecs/lume-2.2.3-1.rockspec
@@ -1,0 +1,21 @@
+package = "lume"
+version = "2.2.3-1"
+source = {
+   url = "git://github.com/rxi/lume",
+   tag = "v2.2.3"
+}
+description = {
+   summary = "A collection of functions for Lua, geared towards game development.",
+   detailed = "A collection of functions for Lua, geared towards game development.",
+   homepage = "http://github.com/rxi/lume",
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1, < 5.4"
+}
+build = {
+   type = "builtin",
+   modules = {
+      lume = "lume.lua"
+   }
+}


### PR DESCRIPTION
This lets people install and manage lume in their projects using [luarocks](luarocks.org).
To test:
```
$ luarocks install lume-scm-1.rockspec
```
If you'd like to upload these to the central luarocks.org service, you can get an API key and do:
```
$ luarocks upload --api-key=<thekey> lume-scm-1.rockspec
$ luarocks upload rockspecs/lume-scm-1.rockspec
```
I can also maintain the luarocks.org part if you don't mind the occasional fluffy PR.