### PR TITLE
lume.hotswap - Fix three edge cases that lead to a crash

### DIFF
--- a/lume.lua
+++ b/lume.lua
@@ -694,7 +694,11 @@ function lume.hotswap(modname)
     local oldmt, newmt = getmetatable(old), getmetatable(new)
     if oldmt and newmt then update(oldmt, newmt) end
     for k, v in pairs(new) do
-      if type(v) == "table" then update(old[k], v) else old[k] = v end
+      if type(v) == "table" and type(old[k]) == "table" then
+        update(old[k], v)
+      else
+        old[k] = v
+      end
     end
   end
   local err = nil
@@ -707,9 +711,11 @@ function lume.hotswap(modname)
   xpcall(function()
     package.loaded[modname] = nil
     local newmod = require(modname)
-    if type(oldmod) == "table" then update(oldmod, newmod) end
+    if type(newmod) == "table" and type(oldmod) == "table" then
+      update(oldmod, newmod)
+    end
     for k, v in pairs(oldglobal) do
-      if v ~= _G[k] and type(v) == "table" then
+      if v ~= _G[k] and type(v) == "table" and type(_G[k]) == "table" then
         update(v, _G[k])
         _G[k] = v
       end


### PR DESCRIPTION
I found three edge cases that can lead to a crash in lurker. All of these have to do with calling `update` on a non-table object. In order of how reasonable they are:

1. Adding a new table field to an updated object
```lua
return {}
```
```lua
return {a = {}}
```

2. Changing a global from a table to a value
```lua
a = {}
```
```lua
a = 3
```

3. Changing the return value of a module from a table to a value
```lua
return {}
```
```lua
return 3
```

One of these can be solved by just checking in `update` itself, but the other two require checks before calling `update`.