### PR TITLE
Make random consistent: never output the top of the bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ local x, y = lume.vector(0, 10) -- Returns 10, 0
 ```
 
 #### lume.random([a [, b]])
-Returns a random number between `a` and `b`. If only `a` is supplied a number
-between `0` and `a` is returned. If no arguments are supplied a random number
-between `0` and `1` is returned.
+Returns a random floating-point number between `a` and `b`. Unlike math.random,
+passing two integers will not return an integer.
+
+With both args, returns a number in the range `[a,b)`.
+If only `a` is supplied, returns a number in the range `[0,a)`.
+If no arguments are supplied, returns a number in the range `[0,1)`.
 
 #### lume.randomchoice(t)
 Returns a random value from array `t`. If the array is empty an error is

--- a/lume.lua
+++ b/lume.lua
@@ -132,7 +132,7 @@ end
 
 function lume.random(a, b)
   if not a then a, b = 0, 1 end
-  if not b then b = 0 end
+  if not b then a, b = 0, a end
   return a + math.random() * (b - a)
 end
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -93,10 +93,30 @@ tests["lume.vector"] = function()
 end
 
 -- lume.random
+local function check_bounds(a, count)
+  if 0 <= a and a < 1 then
+    return count + 1
+  end
+  return count
+end
 tests["lume.random"] = function()
   testeq( type(lume.random()),      "number" )
   testeq( type(lume.random(1)),     "number" )
   testeq( type(lume.random(1, 2)),  "number" )
+
+  -- Static seed to improve consistency. However, different versions of lua may
+  -- produce different sequences.
+  math.randomseed(0)
+  local in_bounds = 0
+  local iterations = 1000
+  for i=1,iterations do
+    -- random always outputs in [a,b). Test all argument versions but with the
+    -- same 0,1 bounds to produce results in [0,1).
+    in_bounds = check_bounds(lume.random(), in_bounds)
+    in_bounds = check_bounds(lume.random(1), in_bounds)
+    in_bounds = check_bounds(lume.random(0, 1), in_bounds)
+  end
+  testeq(in_bounds, iterations * 3)
 end
 
 -- lume.randomchoice

--- a/test/test.lua
+++ b/test/test.lua
@@ -553,7 +553,7 @@ tests["lume.trace"] = function()
   local oldprint = print
   local file, line, msg
   print = function(x)
-    file, line, msg = x:match("(.-):(.-): (.*)")
+    file, line, msg = x:match("(.-):(%d-): (.*)")
   end
   lume.trace("Hi world", 123.456, 1, nil)
   print = oldprint


### PR DESCRIPTION
`lume.random(1)` can sometimes return 1, but `lume.random()` and `lume.random(0,1)` will never return 1. (And the converse for zero: they should all be able to produce 0.) Change the single argument version to conform to the same range regardless of inputs. Update the documentation to make the output range explicit using language similar to math.random.

Add a test that had two failures on the old code for the single argument
version:

  FAIL test.lua:110: testeq(postcond.expected.count > 0, true)
           Expected "true" got "false"
  FAIL test.lua:111: testeq(postcond.unexpected.count, 0)
           Expected 0.00 got 3.00

All tests pass.