### PR TITLE
Add map to scale function

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ lume.round(2.3) -- Returns 2
 lume.round(123.4567, .1) -- Returns 123.5
 ```
 
+#### lume.maptoscale(x, inMin, inMax, outMin, outMax)
+Scales `x` from one range to another.
+```lua
+lume.maptoscale(0.75, 0, 1, -100, 100) -- Returns 50.0
+```
+
 #### lume.sign(x)
 Returns `1` if `x` is 0 or above, returns `-1` when `x` is negative.
 

--- a/lume.lua
+++ b/lume.lua
@@ -90,6 +90,11 @@ function lume.round(x, increment)
 end
 
 
+function lume.maptoscale (value, inMin, inMax, outMin, outMax)
+  return (input - inMin) * (outMax - outMin) / (inMax - inMin) + outMin
+end
+
+
 function lume.sign(x)
   return x < 0 and -1 or 1
 end

--- a/lume.lua
+++ b/lume.lua
@@ -90,8 +90,8 @@ function lume.round(x, increment)
 end
 
 
-function lume.maptoscale (value, inMin, inMax, outMin, outMax)
-  return (input - inMin) * (outMax - outMin) / (inMax - inMin) + outMin
+function lume.maptoscale (x, inMin, inMax, outMin, outMax)
+  return (x - inMin) * (outMax - outMin) / (inMax - inMin) + outMin
 end
 
 


### PR DESCRIPTION
The map to scale function converts a number from one scale to another. A common use case is converting a value between 0 and 1 to another scale, such as 0 to 255. I have found myself using this function quite a bit while working on my games and thought it would be a great addition to this library.